### PR TITLE
Refer to upstream when creating new branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function setupHeadFeeder() {
       }
 
       repo.fetchAllRemotes()
-      repo.updateLocal()
+      repo.updateDefaultBranch()
       repo.createNewBranch(shortHash)
 
       if (repo.hasConflicts('cherry-pick', hash)) {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -18,9 +18,15 @@ class Repository {
       Git.exec(`remote add ${this.remote.head.name} ${this.remote.head.url}`)
       Git.exec(`config user.name "${this.user.name}"`)
       Git.exec(`config user.email "${this.user.email}"`)
+      this.fetchUpstream()
+      if (this.remote.origin.defaultBranch === this.remote.upstream.defaultBranch) {
+        this.createNewBranch('tmp')
+        Git.exec(`branch -D ${this.remote.origin.defaultBranch}`)
+      }
+      this.createNewBranch(`${this.remote.upstream.defaultBranch} ${this.remote.upstream.name}/${this.remote.upstream.defaultBranch}`)
     }
     this.resetChanges()
-    this.checkputDefaultBranch()
+    this.checkoutDefaultBranch()
     Git.exec('branch | grep -v "*" | xargs git branch -D')
   }
 
@@ -29,7 +35,8 @@ class Repository {
     this.fetchHead()
   }
 
-  updateLocal() {
+  updateDefaultBranch() {
+    this.checkoutDefaultBranch()
     this.mergeUpstream()
   }
 
@@ -38,17 +45,15 @@ class Repository {
   }
 
   mergeUpstream() {
-    this.checkputDefaultBranch()
     Git.merge(`${this.remote.upstream.name}/${this.remote.upstream.defaultBranch}`)
-    this.updateRemote(this.remote.origin.defaultBranch)
   }
 
   fetchHead() {
     Git.fetch(this.remote.head.name, this.remote.head.defaultBranch)
   }
 
-  checkputDefaultBranch() {
-    Git.checkout(this.remote.origin.defaultBranch)
+  checkoutDefaultBranch() {
+    Git.checkout(this.remote.upstream.defaultBranch)
   }
 
   updateRemote(branchName) {


### PR DESCRIPTION
This PR resolves #5 
Refer to upstream directly when creating a new branch.
Don't merge upstream to origin.